### PR TITLE
Use correct config for additional clusters

### DIFF
--- a/pkg/kube/kube_handler.go
+++ b/pkg/kube/kube_handler.go
@@ -347,7 +347,7 @@ func (a *kubeHandler) getSvcClientsetForCluster(cluster string, config *rest.Con
 		svcConfig := *config
 		svcConfig.BearerToken = additionalCluster.ServiceToken
 
-		svcClientset, err = a.clientsetForConfig(config)
+		svcClientset, err = a.clientsetForConfig(&svcConfig)
 		if err != nil {
 			log.Errorf("unable to create clientset: %v", err)
 			return nil, err


### PR DESCRIPTION
Fix: https://github.com/vmware-tanzu/kubeapps/issues/5033

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing!
 -->

### Description of the change

`clientsetForConfig` uses correct cluster config variable 

https://github.com/vmware-tanzu/kubeapps/blob/11c87926d6cd798af72875d01437d15ae8d85b9a/pkg/kube/kube_handler.go#L333-L336

### Benefits

Correct behavior for getting a list of namespaces for additional clusters

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

- fixes https://github.com/vmware-tanzu/kubeapps/issues/5033

### Additional information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
